### PR TITLE
Rump documentation for srfi-9 and srfi-27

### DIFF
--- a/docs/api/srfi/27.md
+++ b/docs/api/srfi/27.md
@@ -1,0 +1,17 @@
+# SRFI 27 - Sources of random bits
+
+The `(srfi 27)` library provides sources of random bits. See the
+[SRFI document](http://srfi.schemers.org/srfi-27/srfi-27.html) for
+more information.
+
+- `random-integer`
+- `random-real`
+- `default-random-source`
+- `make-random-source`
+- `random-source?`
+- `random-source-state-ref`
+- `random-source-state-set!`
+- `random-source-randomize!`
+- `random-source-pseudo-randomize!`
+- `random-source-make-integers`
+- `random-source-make-reals`

--- a/docs/api/srfi/9.md
+++ b/docs/api/srfi/9.md
@@ -1,0 +1,15 @@
+# SRFI 9 - Defining record types
+
+The `(srfi 9)` library provides support for defining record types. See
+the [SRFI document](http://srfi.schemers.org/srfi-9/srfi-9.html) for
+more information.
+
+- `record?`
+- `define-record-type`
+- `register-simple-type`
+- `make-type-predicate`
+- `make-constructor`
+- `make-getter`
+- `make-setter`
+- `slot-set!`
+- `type-slot-offset`


### PR DESCRIPTION
Hi,
this patch adds rump documentation for srfi-9 and srfi-27 including an export list and a reference to the srfi document. This does not include the symbol next-mrg32k3a from srfi-27.

Regards, Mark