### PR TITLE
Fix bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ icyc : icyc.scm libcyclone.a
 	$(CYCLONE) $<
 
 dispatch.c : generate-c.scm
-	cyclone $<
+	$(CYCLONE) $<
 	./generate-c
 
 libcyclone.a : $(CFILES) $(HEADERS)


### PR DESCRIPTION
Some explanation required -- I like to build cyclone-bootstrap with a different binary name, "cyclone-bootstrap", and then use it to build cyclone, but if the name `cyclone` is hardcoded instead of using `$(CYCLONE)`, the build fails.