### PR TITLE
read-string: return EOF if nothing can be read

### DIFF
--- a/scheme/base.sld
+++ b/scheme/base.sld
@@ -645,21 +645,23 @@
       (let ((port (if (null? opts)
                       (current-input-port)
                       (car opts))))
-        (let loop ((acc '())
-                   (i k)
-                   (chr #f))
-          (cond
-            ((eof-object? chr)
-             (list->string 
-               (reverse acc)))
-            ((zero? i)
-             (list->string 
-               (reverse 
-                 (if chr (cons chr acc) acc))))
-            (else
-             (loop (if chr (cons chr acc) acc)
-                   (- i 1)
-                   (read-char port)))))))
+        (if (eof-object? (peek-char port))
+            (eof-object)
+            (let loop ((acc '())
+                       (i k)
+                       (chr #f))
+              (cond
+               ((eof-object? chr)
+                (list->string
+                 (reverse acc)))
+               ((zero? i)
+                (list->string
+                 (reverse
+                  (if chr (cons chr acc) acc))))
+               (else
+                (loop (if chr (cons chr acc) acc)
+                      (- i 1)
+                      (read-char port))))))))
     (define (flush-output-port . port)
       (if (null? port)
         (Cyc-flush-output-port (current-output-port))


### PR DESCRIPTION
R7RS states that there's three possible scenarios for read-string:

- More characters can be read than asked for (return string)
- Less characters can be read than asked for (return string)
- No characters can be read (return EOF)

This commit ensures the last scenario works as intended.