### PR TITLE
Enable Travis for continuous integration testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,45 @@
+language: c
+sudo: required
+matrix:
+  include:
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - libtommath-dev
+    - os: linux
+      compiler: clang
+      addons:
+        apt:
+          packages:
+            - libtommath-dev
+            - clang-3.9
+    - os: osx
+      image: xcode8
+notifications:
+  email: false
+before_install:
+  - if [ "$(uname)" = "Darwin" ]; then
+      brew update;
+      brew install -v libtommath concurrencykit;
+    fi
+  - |
+      git clone https://github.com/concurrencykit/ck.git ${HOME}/ck
+      cd ${HOME}/ck
+      git checkout v0.6.0
+      ./configure PREFIX=/usr
+      make all
+      sudo make install
+      if [ "$(uname)" = "Linux" ]; then
+        sudo ldconfig
+      fi
+  - |
+      git clone https://github.com/justinethier/cyclone-bootstrap.git ${HOME}/cyclone-bootstrap
+      cd ${HOME}/cyclone-bootstrap
+      make
+      sudo make install
+script:
+  - make
+  - sudo make install
+  - make test

--- a/Makefile.config
+++ b/Makefile.config
@@ -15,13 +15,20 @@ endif
 
 # Compiler options
 CFLAGS       ?= -O2 -fPIC -Wall -Iinclude
-COMP_CFLAGS  ?= -O2 -fPIC -Wall -I$(PREFIX)/include -L$(PREFIX)/lib -Wl,--export-dynamic
+COMP_CFLAGS  ?= -O2 -fPIC -Wall -I$(PREFIX)/include -L$(PREFIX)/lib
 # Use these lines instead for debugging or profiling
 #CFLAGS = -g -Wall
 #CFLAGS = -g -pg -Wall
 
 # Linker options
-LDFLAGS ?= -Wl,--export-dynamic -L.
+LDFLAGS ?= -L.
+ifeq ($(OS),Darwin)
+LDFLAGS     += -Wl,-export-dynamic -Wl,-undefined -Wl,dynamic_lookup
+COMP_CFLAGS += -Wl,-export-dynamic
+else
+LDFLAGS     += -Wl,--export-dynamic
+COMP_CFLAGS += -Wl,--export-dynamic
+endif
 
 # /usr/local is not in the search path by default on FreeBSD, so if libtommath and/or
 # concurrencykit was installed via Ports, it won't be picked up without explicitly looking
@@ -35,7 +42,7 @@ endif
 CC_PROG ?= "$(CC) ~src-file~ $(COMP_CFLAGS) -c -o ~exec-file~.o"
 CC_EXEC ?= "$(CC) ~exec-file~.o ~obj-files~ $(LIBS) $(COMP_CFLAGS) -o ~exec-file~"
 CC_LIB  ?= "$(CC) ~src-file~ $(COMP_CFLAGS) -c -o ~exec-file~.o"
-CC_SO   ?= "$(CC) -shared -rdynamic -o ~exec-file~.so ~exec-file~.o"
+CC_SO   ?= "$(CC) -shared $(LDFLAGS) -o ~exec-file~.so ~exec-file~.o"
 
 AR        ?= ar
 #CD        ?= cd
@@ -57,8 +64,8 @@ DESTDIR   ?=
 
 # Automatically detect platform-specific flags, instead of using autoconf
 #CYC_PLATFORM_HAS_MEMSTREAM ?= 1
-CYC_PLATFORM_HAS_MEMSTREAM := $(shell echo "main(){char *buf; int len; open_memstream(&buf, &len);}" | gcc -xc - >/dev/null 2>/dev/null && echo 1 || echo 0)
-CYC_PLATFORM_HAS_FMEMOPEN := $(shell echo "main(){char *buf; fmemopen(&buf, 0, \"r\");}" | gcc -xc - >/dev/null 2>/dev/null && echo 1 || echo 0)
+CYC_PLATFORM_HAS_MEMSTREAM := $(shell echo "main(){char *buf; int len; open_memstream(&buf, &len);}" | $(CC) -xc - >/dev/null 2>/dev/null && echo 1 || echo 0)
+CYC_PLATFORM_HAS_FMEMOPEN := $(shell echo "main(){char *buf; fmemopen(&buf, 0, \"r\");}" | $(CC) -xc - >/dev/null 2>/dev/null && echo 1 || echo 0)
 
 # code from chibi's makefile to detect platform
 ifndef PLATFORM


### PR DESCRIPTION
This PR adds CI testing on Linux with both Clang and GCC, and on macOS. The first commit adds the Travis configuration file for the builds and the second commit corrects a linker flag on macOS.

What you'll need to do is create an account associated with your GitHub profile on https://travis-ci.org, then once you're signed in, enable building on cyclone. Click the little gear to make any changes to the settings you'd like. I recommend enabling "Build only if .travis.yml is present" and keeping the other default settings.

Once it's enabled we might have to close and reopen this PR to force a build.

Fixes #163 