### PR TITLE
Make the Travis badge a link to Travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [<img src="docs/images/cyclone-logo-04-header.png" alt="cyclone-scheme">](http://github.com/justinethier/cyclone)
 
-<img src="https://travis-ci.org/justinethier/cyclone.svg?branch=master">
+[![Travis CI](https://travis-ci.org/justinethier/cyclone.svg?branch=master)](https://travis-ci.org/justinethier/cyclone)
 
 Cyclone is a brand-new Scheme-to-C compiler that allows practical application development using R<sup>7</sup>RS Scheme. [Cheney on the MTA](http://www.pipeline.com/~hbaker1/CheneyMTA.html) is used by Cyclone's runtime to implement full tail recursion, continuations, and generational garbage collection. In addition, the Cheney on the MTA concept has been extended to allow execution of multiple native threads. An on-the-fly garbage collector is used to manage the second-generation heap and perform major collections without "stopping the world".
 


### PR DESCRIPTION
Just a small adjustment so that when you click on the badge, you're taken to the Travis site with the most recent build.