### PR TITLE
Updated scheme/cyclone/cgen.sld to insert correct

### DIFF
--- a/scheme/cyclone/cgen.sld
+++ b/scheme/cyclone/cgen.sld
@@ -355,11 +355,8 @@
     ;(write `(DEBUG ,body))
     (string-append 
      preamble 
-     (c:serialize body "  ") ;" ;\n"
-;     "int main (int argc, char* argv[]) {\n"
-;     "  return 0;\n"
-;     " }\n"
-)))
+     (c:serialize body "  ")
+     " ;\n")))
 
 ;; c-compile-exp : exp (string -> void) -> string
 ;;


### PR DESCRIPTION
A program as simple as the following:

(import (scheme base))
(if (system "ls")
    1)

generates a compilation error:

$ cyclone -td test.scm
test.c: In function ‘c_entry_pt_first_lambda’:
test.c:327:1: error: expected ‘;’ before ‘}’ token
 } else { 
 ^

The corresponding C code is (with manually corrected indentation):

static void c_entry_pt_first_lambda(void *data, int argc, closure cont, object value) {
    make_utf8_string_with_len(c_735, "ls", 2, 2);
    if( (boolean_f != Cyc_system(&c_735)) ){
        __halt(obj_int2obj(1))    **<--- missing semi-colon**
    } else { 
        __halt(boolean_f);
    } ;
   ;   **<--- extra semi-colon** (don't know why and where, still revising code)
}

Uncommenting ";\n" on line 358 the makes the code compile properly, although this line appends semi-colons to code that already have them. The extra semi-colons produce no errors, as it is valid C, but it is an really ugly hack and maybe that's why it was commented out.

AFAIK the problem is that the program ends with (%halt 1), which is itself translated into __halt(obj_int2obj(1)), which itself does not receives a semi-colon at its end. I couldn't find any other procedure that wouldn't have a semi-colon appended to it during translation, so I suppose this is a corner case. I couldn't find the exact line where %halt is converted to __halt(...) and I'd love to discover it.

In this pull request I also removed commented lines defining an int main() in a really inappropriate place.

Cheers,
Arthur