### PR TITLE
Previous try to correct semi-colon bug failed

### DIFF
--- a/scheme/cyclone/cgen.sld
+++ b/scheme/cyclone/cgen.sld
@@ -334,10 +334,16 @@
     (append (c:allocs cp1) (c:allocs cp2))))
 
 (define (c:serialize cp prefix)
+  (let* ((body (c:body cp))
+         (blen (string-length body)))
     (string-append
-        (c:allocs->str (c:allocs cp) prefix)
-        prefix
-        (c:body cp)))
+     (c:allocs->str (c:allocs cp) prefix)
+     prefix
+     body
+     (if (and (> blen 0)
+              (not (eq? #\; (string-ref body (- blen 1))))) ; last char
+         ";"
+         ""))))
 
 ;; c-compile-program : exp -> string
 (define (c-compile-program exp src-file)
@@ -348,8 +354,7 @@
     ;; (write `(DEBUG ,body))
     (string-append 
      preamble 
-     (c:serialize body "  ")
-     " ;\n")))
+     (c:serialize body "  "))))
 
 ;; c-compile-exp : exp (string -> void) -> string
 ;;


### PR DESCRIPTION
Justin, the previous pull request did not corrected the bug on '%halt' translation into '__halt(...)'. I changed the c:seralize procedure to check if the end of the compiled expression has a semi-colon at its end. If not, add one.

It works fine and passes all the tests (although this specific error doesn't is not catched up with 'make test'). 

I'm a bit worried about cgen.sld because it doesn't have a systematic way of emiting C code. It passes a parameter 'append-preamble' not used a single time. The term 'prefix' means indentation in one section but when dealing with macros it means a prefix to a variable name. The procedure I modified, 'c:serialize' is used 4 or 5 times and is not default. I thought about overhauling indentation procedures, but I'm not sure I'm skilled enough. If you think it is a good idea, I could put effort on this and I'd be happy if you could supervise me along the process.

The worry is because before this patches I couldn't compile a simple program (the prototype for cyclone-winds) and I'm quite not satisfied with the solution because extra semi-colons are being print after 'return_closcall' and others and I really don't know why. Although still valid C code, trusting too much on results without understanding the cause makes me skeptical.

Thanks,
Arthur