### PR TITLE
Homebrew compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,8 @@ runtime.o : runtime.c $(HEADERS)
 					$< -o $@
 
 libcyclone.a : runtime.o gc.o dispatch.o mstreams.o hashset.o
-	$(AR) rcs $@ $^ 
+	$(CREATE_LIBRARY_COMMAND) $(CREATE_LIBRARY_FLAGS) $@ $&
+	$(RANLIB_COMMAND)
 # Instructions from: http://www.adp-gmbh.ch/cpp/gcc/create_lib.html
 # Note compiler will have to link to this, eg:
 #Linking against static library

--- a/Makefile.config
+++ b/Makefile.config
@@ -107,4 +107,3 @@ else
 PLATFORM=unix
 endif
 endif
-

--- a/Makefile.config
+++ b/Makefile.config
@@ -4,6 +4,8 @@
 #
 # Configuration options for the makefile
 
+& = $(filter-out %.h %.d,$^)
+
 CYC_PROFILING ?= 
 #CYC_PROFILING ?= -g -pg
 
@@ -105,3 +107,4 @@ else
 PLATFORM=unix
 endif
 endif
+


### PR DESCRIPTION
### Summary

* Updates `Makefile` for [homebrew](https://brew.sh/) compatibility. cyclone can now build itself on macOS after cyclone-bootstrap has been run.

### Impact

* None for non-macOS platforms.
* On macOS cyclone can now build itself after cyclone-bootstrap has been run.

### Limitations / TODO

* The compiler output is not as clean as linux– some warnings and notes are still produced. (`warning: shifting a negative signed value is undefined [-Wshift-negative-value]` and `note: expanded from macro`) – these can be cleaned up in another PR.

### Detail

* `libtool` is used on macOS instead of `ar`
* Here are the homebrew formulas used for testing:
  * [cyclone-bootstrap](https://github.com/adamfeuer/homebrew-cyclone/blob/master/cyclone-bootstrap.rb)
  * [cyclone](https://github.com/adamfeuer/homebrew-cyclone/blob/master/cyclone.rb)

### Testing

* `make; make install; make test; make clean; make; make install; make test` was run on both macOS and linux
* homebrew tap formulas were run for cyclone-bootstrap and cyclone
