### PR TITLE
Fix Concurrency Kit version tag in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   - |
       git clone https://github.com/concurrencykit/ck.git ${HOME}/ck
       cd ${HOME}/ck
-      git checkout v0.6.0
+      git checkout 0.6.0
       ./configure PREFIX=/usr
       make all
       sudo make install


### PR DESCRIPTION
CK git tags don't have a `v` prefix before the version number. The current Travis log says:

`error: pathspec 'v0.6.0' did not match any file(s) known to git`

* The build seems to pass anyway, even though it ends up using the latest CK version.
* The Travis config `before_install` section has many commands under one bullet point (the `git checkout` being one of them). If one of the sub-commands fails, the error doesn't propagate upwards to the build runner. Should probably have each command as its own bullet point whenever possible?