### PR TITLE
Improved "-p" flag to read/evalute all sexp passed

### DIFF
--- a/icyc.scm
+++ b/icyc.scm
@@ -94,7 +94,7 @@ Options:
          (else
           (let* ((sexp-str (apply string-append sexp-strs))
                  (in-port (open-input-string sexp-str))
-                 (sexp (read in-port)))
+                 (sexp (cons 'begin (read-all in-port)))
             (display
               (eval sexp))
             (newline)


### PR DESCRIPTION
@justinethier, although the `-p` can handle multiple occurrences of sexps to evaluate, the following would occur, which does not seem an interesting behaviour to me:

```scheme
$ icyc -p "(define a 1) (display a)" 
ok  ;; evaluation of the first sexp - the second is explicitly ignored
```

The following also doesn't work, so we can conclude there is no continuity between sexps:

```scheme
$ icyc -p "(define a 1)" -p "(display a)" 
Error: Unbound variable: a 
Call history:
scheme/eval.sld:analyze-variable
scheme/base.sld:Cyc-map-loop-1
scheme/cyclone/util.sld:env:lookup-variable-value
scheme/cyclone/util.sld:env:_lookup-variable-value
scheme/base.sld:Cyc-map-loop-1
scheme/cyclone/util.sld:env:lookup-variable-value
scheme/cyclone/util.sld:env:_lookup-variable-value
scheme/base.sld:error
scheme/base.sld:raise
```

By reading all the sexps passed, be they passed in one "-p" flag or more, or even as many sexps inside one "-p" flag,  and wrapping them up in a `(begin ...)`  we can get the correct result:

```scheme
$ icyc -p "(define a 1) (display a)" 
1
```