### PR TITLE
Added 'cvoid' type into (cyclone foreign) and fixed bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
-
 ## 0.19 - TBD
 
+Features
+
+- Added `cvoid` type into `(cyclone foreign)`.
+
+Bug Fixes
+
+- Fixed `make_empty_bytevector` and `make_c_opaque` parameters on `(cyclone foreign)`.
 
 ## 0.18 - June 8, 2020
 

--- a/docs/api/cyclone/foreign.md
+++ b/docs/api/cyclone/foreign.md
@@ -69,4 +69,5 @@ Scheme | C
 `double` | `double`
 `bignum` | `mp_int`
 `opaque` | `void *`
+`cvoid` | `void`
 

--- a/libs/cyclone/foreign.sld
+++ b/libs/cyclone/foreign.sld
@@ -117,6 +117,8 @@
              (string-append "(((bytevector_type *)" ,code ")->data)"))
             ((opaque)
              (string-append "opaque_ptr(" ,code ")"))
+            ((cvoid)
+             "Cyc_VOID")
             (else
               (error "scm->c unable to convert scheme object of type " ,type)))))))
   
@@ -168,7 +170,7 @@
            (let ((var (mangle (gensym 'var))))
            (cons
              (string-append 
-               "make_empty_bytevector(data," var ");"
+               "make_empty_bytevector(" var ");"
                var "->data = " ,code ";")
              (string-append "&" var)
            )))
@@ -176,9 +178,12 @@
            (let ((var (mangle (gensym 'var))))
            (cons
              (string-append 
-               "make_c_opaque(data," var ", " ,code ");")
-             (string-append "&" var)
-           )))
+               "make_c_opaque(" var ", " ,code ");")
+             (string-append "&" var))))
+          ((cvoid)
+           (cons
+            (string-append ,code ";")
+            "Cyc_VOID"))
           (else
             (error "c->scm unable to convert C object of type " ,type)))))))
   


### PR DESCRIPTION
@justinethier, I couldn't make the new type named `void` probably due to a name clash with the `void` procedure itself. Is there a workaround? `cvoid` is not as elegant as `(cyclone foreign)` itself :)