### PR TITLE
Fix a crash in record predicates

### DIFF
--- a/scheme/base.sld
+++ b/scheme/base.sld
@@ -1973,6 +1973,7 @@
 (define (make-type-predicate pred name)
   (lambda (obj)
     (and (vector? obj)
+         (= (vector-length obj) 3)
          (equal? (vector-ref obj 0) record-marker)
          (equal? (vector-ref obj 1) name))))
 (define (make-constructor make name)


### PR DESCRIPTION
Hi there, I ran into a bug where I needed to branch on a procedure receiving either a record or a vector, and noticed that record type predicates don't check the length of the target before checking if the vector is actually a record so when my procedure received a vector with less than two entries it would crash when trying to access the record marker or record type name.

For example:
```scheme
(define-record-type <my-record> (my-record) my-record?)
(let ((v (vector)))
  (if (my-record? v) #t #f))
```
would crash with
```
Error: vector-ref - invalid index: 0 
```

So I added a check to the procedure returned from `make-type-predicate` to verify that the vector has three entries.

Of course, there is still another problem in that the result of the following expression results in `#t`

```scheme
(vector? (my-record))
```