### PR TITLE
Unless/when don't have alternate clause

### DIFF
--- a/scheme/base.sld
+++ b/scheme/base.sld
@@ -483,15 +483,13 @@
           (if (null? (cdr exp)) (error/loc "empty when" exp))
           (if (null? (cddr exp)) (error/loc "no when body" exp))
           `(if ,(cadr exp)
-               ((lambda () ,@(cddr exp)))
-               #f))))
+               ((lambda () ,@(cddr exp)))))))
     (define-syntax unless
       (er-macro-transformer
         (lambda (exp rename compare)
           (if (null? (cdr exp)) (error/loc "empty unless" exp))
           (if (null? (cddr exp)) (error/loc "no unless body" exp))
-          `(if ,(cadr exp)
-               #f
+          `(if (not ,(cadr exp))
                ((lambda () ,@(cddr exp)))))))
   (define-syntax do
     (er-macro-transformer


### PR DESCRIPTION
They both should not return `#f`. The correct behavior is allowed due to the fix for #377.