### PR TITLE
Flush current-output-port after writing prompt to it

### DIFF
--- a/scheme/repl.sld
+++ b/scheme/repl.sld
@@ -47,6 +47,7 @@
           (newline)
           (repl))
         (display "cyclone> ")
+        (flush-output-port)
         (let ((obj (read)))
           (if (eof-object? obj)
               (newline) ;; Quick way to exit REPL


### PR DESCRIPTION
On Unix-like operating systems stdio.h (which Cyclone seems to use
internally) is line-buffered. As such, the prompt will only be written
after a newline character is written (since the prompt itself doesn't
contain a newline) which is probably not what was
intended here. This commit fixes this issue by always flushing the
current-output-port after writing the prompt string.