### PR TITLE
Don't use conditional assignment operator for CFLAGS/LDFLAGS

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -23,7 +23,7 @@ LIBS += -ldl
 endif
 
 # Compiler options
-CFLAGS       ?= $(CYC_PROFILING) $(CYC_GCC_OPT_FLAGS) -fPIC -Wall -Wno-shift-negative-value -Wno-unused-command-line-argument -Iinclude
+CFLAGS       += $(CYC_PROFILING) $(CYC_GCC_OPT_FLAGS) -fPIC -Wall -Wno-shift-negative-value -Wno-unused-command-line-argument -Iinclude
 BASE_CFLAGS  ?= $(CYC_PROFILING) $(CYC_GCC_OPT_FLAGS) -fPIC -Wall -Wno-shift-negative-value -Wno-unused-command-line-argument -I$(PREFIX)/include
 # Used by Cyclone to compile programs, no need for PIC there
 BASE_PROG_CFLAGS  ?= $(CYC_PROFILING) $(CYC_GCC_OPT_FLAGS) -Wall -I$(PREFIX)/include
@@ -40,7 +40,7 @@ endif
 #CFLAGS = -g -pg -Wall
 
 # Linker options
-LDFLAGS ?= -L. $(CYC_PROFILING)
+LDFLAGS += -L. $(CYC_PROFILING)
 LIBRARY_OUTPUT_FILE = libcyclone.a
 ifeq ($(OS),Darwin)
 LDFLAGS     += -Wl,-undefined -Wl,dynamic_lookup

--- a/Makefile.config.raspberry-pi-2
+++ b/Makefile.config.raspberry-pi-2
@@ -20,14 +20,14 @@ CREATE_LIBRARY_COMMAND = $(AR)
 CREATE_LIBRARY_FLAGS = rcs
 
 # Compiler options
-CFLAGS       ?= -O2 -fPIC -Wall -march=armv6k -Iinclude
+CFLAGS       += -O2 -fPIC -Wall -march=armv6k -Iinclude
 COMP_CFLAGS  ?= -O2 -fPIC -Wall -march=armv6k -I$(PREFIX)/include -L$(PREFIX)/lib
 # Use these lines instead for debugging or profiling
 #CFLAGS = -g -Wall
 #CFLAGS = -g -pg -Wall
 
 # Linker options
-LDFLAGS ?= -L.
+LDFLAGS += -L.
 ifeq ($(OS),Darwin)
 LDFLAGS     += -Wl,-export_dynamic -Wl,-undefined -Wl,dynamic_lookup
 COMP_CFLAGS += -Wl,-export_dynamic


### PR DESCRIPTION
The [conditional variable assignment operator](https://www.gnu.org/software/make/manual/make.html#index-conditional-variable-assignment) in Makefiles (`?=`) will only assign a value if its not defined yet. However, CFLAGS/LDFLAGS are commonly defined as environment variables to pass custom compiler/linker flags (e.g. `-Os`). Unfortunately, Cyclone adds mandatory compiler flags (without which it doesn't compile) via the conditional variable assignment operator which is incorrect as these flags will not be added if CFLAGS/LDFLAGS is defined in the environment. This commit fixes this issue by appending flags to CFLAGS/LDFLAGS instead of using the conditional assignment operator.

This should also fix weird hacks such as this: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=cyclone-scheme#n27