### PR TITLE
Improve Makefile prerequisites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,12 +150,12 @@ doc :
 
 .PHONY: clean full bench bootstrap tags indent debug test doc
 
-$(TESTS) : %: %.scm
+$(TESTS) : %: %.scm cyclone libs
 	$(CYCLONE_LOCAL) -I . $<
 	./$@
 	rm -rf $@
 
-$(EXAMPLES) : %: %.scm
+$(EXAMPLES) : %: %.scm cyclone libs
 	$(CYCLONE_LOCAL) $<
 
 game-of-life :
@@ -166,13 +166,13 @@ hello-library/hello :
 
 libs : $(COBJECTS)
 
-$(COBJECTS) : %.o: %.sld
+$(COBJECTS) : %.o: %.sld cyclone
 	$(CYCLONE_LOCAL) $<
 
 cyclone : cyclone.scm $(CYC_RT_LIB) $(CYC_BN_LIB)
 	$(CYCLONE_SYSTEM) cyclone.scm
 
-icyc : icyc.scm $(CYC_RT_LIB) $(CYC_BN_LIB)
+icyc : icyc.scm $(CYC_RT_LIB) $(CYC_BN_LIB) cyclone libs
 	$(CYCLONE_LOCAL) $<
 
 $(CYC_RT_LIB) : $(CFILES) $(HEADERS) $(CYC_BN_LIB)


### PR DESCRIPTION
Since commit 15a8f2cfe51bffa2844159cd267bd896a1c7ed46 the build order must be as follows:

1. Bootstrap cyclone.scm using a pre-existing compiler.
2. Using cyclone from the previous step, build all libraries.
3. Using the artifacts from the previous two steps, build icyc, examples, and tests.

This commit updates the Makefile prerequisites accordingly to reflect this change in build order. Otherwise, Cyclone does not correctly compile in parallel build mode with `-jN`.