### PR TITLE
Makefile: Add `-A libs` to CYCLONE_LOCAL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ include Makefile.config
 # compiler (EG: from bootstrap or an earlier cyclone version). Everything
 # else can then be built using our local binary.
 CYCLONE_SYSTEM = cyclone -A .
-CYCLONE_LOCAL = ./cyclone -A . -COPT '-Iinclude' -CLNK '-L.'
+CYCLONE_LOCAL = ./cyclone -A . -A libs -COPT '-Iinclude' -CLNK '-L.'
 CCOMP = $(CC) $(CFLAGS)
 INDENT_CMD = indent -linux -l80 -i2 -nut
 


### PR DESCRIPTION
Otherwise `make libs` cannot find `(cyclone test)`:

	./cyclone -A . -COPT '-Iinclude' -CLNK '-L.' libs/cyclone/test.sld
	Error: Unable to open file: "/usr/lib/cyclone/cyclone/test.scm"

	make: *** [Makefile:170: libs/cyclone/test.o] Error

Testing Procedure:

1. Install a pre-compiled cyclone version globally (for `CYCLONE_SYSTEM`)
2. Run `make cyclone`
3. Uninstall the global cyclone version (should not be needed after this step)
4. Run `make libs` fails without this commit, should pass with it
5. Run `make icyc` 