### PR TITLE
Allow prepending include/library search path through -COPT/-CLNK

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -32,13 +32,8 @@ CFLAGS       += $(CYC_PROFILING) $(CYC_GCC_OPT_FLAGS) -fPIC -Wall -Wno-shift-neg
 BASE_CFLAGS  ?= $(CYC_PROFILING) $(CYC_GCC_OPT_FLAGS) -fPIC -Wall -Wno-shift-negative-value -Wno-unused-command-line-argument -I$(PREFIX)/include
 # Used by Cyclone to compile programs, no need for PIC there
 BASE_PROG_CFLAGS  ?= $(CYC_PROFILING) $(CYC_GCC_OPT_FLAGS) -Wall -I$(PREFIX)/include
-ifeq ($(OS),Darwin)
-COMP_CFLAGS  ?= $(BASE_CFLAGS) -L$(PREFIX)/lib
-COMP_PROG_CFLAGS  ?= $(BASE_PROG_CFLAGS) 
-else
-COMP_CFLAGS  ?= $(BASE_CFLAGS) -L$(PREFIX)/lib
+COMP_CFLAGS       ?= $(BASE_CFLAGS) -L$(PREFIX)/lib
 COMP_PROG_CFLAGS  ?= $(BASE_PROG_CFLAGS)
-endif
 
 # Use these lines instead for debugging or profiling
 #CFLAGS = -g -Wall

--- a/Makefile.config
+++ b/Makefile.config
@@ -31,9 +31,11 @@ endif
 CFLAGS       += $(CYC_PROFILING) $(CYC_GCC_OPT_FLAGS) -fPIC -Wall -Wno-shift-negative-value -Wno-unused-command-line-argument -Iinclude
 BASE_CFLAGS  ?= $(CYC_PROFILING) $(CYC_GCC_OPT_FLAGS) -fPIC -Wall -Wno-shift-negative-value -Wno-unused-command-line-argument -I$(PREFIX)/include
 # Used by Cyclone to compile programs, no need for PIC there
-BASE_PROG_CFLAGS  ?= $(CYC_PROFILING) $(CYC_GCC_OPT_FLAGS) -Wall -I$(PREFIX)/include
-COMP_CFLAGS       ?= $(BASE_CFLAGS) -L$(PREFIX)/lib
-COMP_PROG_CFLAGS  ?= $(BASE_PROG_CFLAGS)
+BASE_PROG_CFLAGS   ?= $(CYC_PROFILING) $(CYC_GCC_OPT_FLAGS) -Wall
+COMP_CFLAGS        ?= $(BASE_CFLAGS)
+COMP_LIBDIRS       ?= -L$(PREFIX)/lib
+COMP_INCDIRS       ?= -I$(PREFIX)/include
+COMP_PROG_CFLAGS   ?= $(BASE_PROG_CFLAGS)
 
 # Use these lines instead for debugging or profiling
 #CFLAGS = -g -Wall
@@ -57,15 +59,15 @@ endif
 # concurrencykit was installed via Ports, it won't be picked up without explicitly looking
 # for it here
 ifeq ($(OS),FreeBSD)
-LDFLAGS += -L/usr/local/lib
-CFLAGS  += -I/usr/local/include
+COMP_LIBDIRS += -L/usr/local/lib
+COMP_INCDIRS += -I/usr/local/include
 endif
 
 
 # Commands "baked into" cyclone for invoking the C compiler
-CC_PROG ?= "$(CC) ~src-file~ $(COMP_PROG_CFLAGS) -c -o ~exec-file~.o"
-CC_EXEC ?= "$(CC) ~exec-file~.o ~obj-files~ $(LIBS) $(COMP_CFLAGS) -o ~exec-file~"
-CC_LIB  ?= "$(CC) ~src-file~ $(COMP_CFLAGS) -c -o ~exec-file~.o"
+CC_PROG ?= "$(CC) ~src-file~ $(COMP_PROG_CFLAGS) ~cc-extra~ $(COMP_INCDIRS) -c -o ~exec-file~.o"
+CC_EXEC ?= "$(CC) ~exec-file~.o ~obj-files~ $(LIBS) $(COMP_CFLAGS) ~ld-extra~ $(COMP_LIBDIRS) -o ~exec-file~"
+CC_LIB  ?= "$(CC) ~src-file~ $(COMP_CFLAGS) ~cc-extra~ $(COMP_LIBDIRS) -c -o ~exec-file~.o"
 CC_SO   ?= "$(CC) -shared $(LDFLAGS) -o ~exec-file~.so ~exec-file~.o"
 
 AR        ?= ar

--- a/cyclone.scm
+++ b/cyclone.scm
@@ -882,12 +882,12 @@
                    (string-append
                      (string-replace-all 
                        (string-replace-all 
-                         ;(Cyc-compilation-environment 'cc-prog) 
-                         (get-comp-env 'cc-prog cc-prog)
-                         "~src-file~" src-file)
+                         (string-replace-all 
+                           ;(Cyc-compilation-environment 'cc-prog) 
+                           (get-comp-env 'cc-prog cc-prog)
+                           "~src-file~" src-file)
+                         "~cc-extra~" cc-opts)
                        "~exec-file~" exec-file)
-                     " "
-                     cc-opts
                      " "
                      cc-opts*))
                  (comp-objs-cmd 
@@ -895,13 +895,13 @@
                    (string-replace-all
                      (string-replace-all
                        (string-replace-all
-                         ;(Cyc-compilation-environment 'cc-exec)
-                         (get-comp-env 'cc-exec cc-exec)
-                         "~exec-file~" exec-file)
+                         (string-replace-all
+                           ;(Cyc-compilation-environment 'cc-exec)
+                           (get-comp-env 'cc-exec cc-exec)
+                           "~exec-file~" exec-file)
+                         "~ld-extra~" cc-prog-linker-opts)
                        "~obj-files~" objs-str)
                      "~exec-file~" exec-file)
-                   " "
-                   cc-prog-linker-opts
                    " "
                    c-linker-options
                    )))
@@ -922,11 +922,11 @@
                (string-append
                 (string-replace-all 
                   (string-replace-all 
-                    (get-comp-env 'cc-lib cc-lib)
-                    "~src-file~" src-file)
+                    (string-replace-all 
+                      (get-comp-env 'cc-lib cc-lib)
+                      "~src-file~" src-file)
+                    "~cc-extra~" cc-opts)
                   "~exec-file~" exec-file)
-                " "
-                cc-opts
                 " "
                 cc-opts*))
               (comp-so-cmd


### PR DESCRIPTION
This commit separates include/library search directory options from "normal" compiler/linker options and places options passed via the `-COPT`/`-CLNK` command-line flags in-between. This allows overwriting the default search paths, since contrary to all other options, the search paths must be prepend for an `-I`/`-L` option to take precedence over an existing one.

To test this, compare the new concatenation of linker/compiler options for `test.scm` [with the previous one](https://github.com/justinethier/cyclone/issues/476#issuecomment-898884369):

```
$ ./cyclone -d -A . -COPT '-Iinclude' -CLNK '-L.' /tmp/test.scm
gcc /tmp/test.c  -O2 -Wall -Iinclude -I/usr/include -c -o /tmp/test.o
gcc /tmp/test.o  /usr/lib/cyclone/scheme/cyclone/common.o  /usr/lib/cyclone/scheme/base.o  /usr/lib/cyclone/scheme/write.o  -pthread -lcyclone -lck -lm -lcyclonebn -ldl  -O2 -fPIC -Wall -Wno-shift-negative-value -Wno-unused-command-line-argument -Wl,--export-dynamic -L. -L/usr/lib -o /tmp/test
```

The important thing to take away here is:

1. `-Iinclude` (as specified via `-COPT`) is added *before* the default `-I/usr/include` but *after* `-O2 -Wall` etc.
2. `-L.` (as specified via `-CLNK` is added *before* the default `-L/usr/lib` but *after* `-Wl,--export-dynamic` etc.

This should (hopefully) make it entirely unnecessary to ever build Cyclone twice in order to have all changes in the current source tree take effect. Without this change, Cyclone will always use system header/libraries of the previous installation since the library/include search path was previously appended instead of prepended (see #476).

Please review this with extra care.

Fixes #476