### PR TITLE
Makefile.config: Move -I$(PREFIX)/include from BASE_CFLAGS to CC_LIB

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -29,7 +29,7 @@ endif
 
 # Compiler options
 CFLAGS       += $(CYC_PROFILING) $(CYC_GCC_OPT_FLAGS) -fPIC -Wall -Wno-shift-negative-value -Wno-unused-command-line-argument -Iinclude
-BASE_CFLAGS  ?= $(CYC_PROFILING) $(CYC_GCC_OPT_FLAGS) -fPIC -Wall -Wno-shift-negative-value -Wno-unused-command-line-argument -I$(PREFIX)/include
+BASE_CFLAGS  ?= $(CYC_PROFILING) $(CYC_GCC_OPT_FLAGS) -fPIC -Wall -Wno-shift-negative-value -Wno-unused-command-line-argument
 # Used by Cyclone to compile programs, no need for PIC there
 BASE_PROG_CFLAGS   ?= $(CYC_PROFILING) $(CYC_GCC_OPT_FLAGS) -Wall
 COMP_CFLAGS        ?= $(BASE_CFLAGS)
@@ -67,7 +67,7 @@ endif
 # Commands "baked into" cyclone for invoking the C compiler
 CC_PROG ?= "$(CC) ~src-file~ $(COMP_PROG_CFLAGS) ~cc-extra~ $(COMP_INCDIRS) -c -o ~exec-file~.o"
 CC_EXEC ?= "$(CC) ~exec-file~.o ~obj-files~ $(LIBS) $(COMP_CFLAGS) ~ld-extra~ $(COMP_LIBDIRS) -o ~exec-file~"
-CC_LIB  ?= "$(CC) ~src-file~ $(COMP_CFLAGS) ~cc-extra~ $(COMP_LIBDIRS) -c -o ~exec-file~.o"
+CC_LIB  ?= "$(CC) ~src-file~ $(COMP_CFLAGS) ~cc-extra~ $(COMP_INCDIRS) -c -o ~exec-file~.o"
 CC_SO   ?= "$(CC) -shared $(LDFLAGS) -o ~exec-file~.so ~exec-file~.o"
 
 AR        ?= ar


### PR DESCRIPTION
This is a follow up to https://github.com/justinethier/cyclone/pull/482#discussion_r758902860

The -I$(PREFIX)/include needs to be moved away from BASE_CFLAGS since,
otherwise, it will be added *before* `~cc-extra~` and thus (partially)
circumvent the changes from #482. Compare the following two Cyclone
invocations with/without this commit.

Without this commit:

	$ ./cyclone -d -A . -A libs -COPT '-Iinclude' -CLNK '-L.' scheme/complex.sld
	gcc scheme/complex.c […] -I/usr/include -Wl,--export-dynamic -Iinclude -L/usr/lib -c

With this commit applied:

	$ ./cyclone -d -A . -A libs -COPT '-Iinclude' -CLNK '-L.' scheme/complex.sld
	gcc scheme/complex.c […] -Wl,--export-dynamic -Iinclude -I/usr/include -c

In #482, I originally removed the -I$(PREFIX)/include from BASE_CFLAGS
entirely. However, back then I forgot to add $(COMP_INCDIRS) to CC_LIB
to account for that. By doing that, this should fix the error from
https://github.com/justinethier/cyclone/pull/482#discussion_r758902860 and align CC_LIB nicely with CC_PROG.

While at it, I also removed $(COMP_LIBDIRS) from CC_LIB, it shouldn't be
needed since the CC_LIB command compiles object files and doesn't do any
linking.

Sorry for not getting it right the first time. I hope this works without problems (: