### PR TITLE
Makefile: Also pass -L. for CYCLONE_SYSTEM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ include Makefile.config
 # Set up Cyclone here to build the compiler itself using a system-installed
 # compiler (EG: from bootstrap or an earlier cyclone version). Everything
 # else can then be built using our local binary.
-CYCLONE_SYSTEM = cyclone -A .
+CYCLONE_SYSTEM = cyclone -A . -CLNK '-L.'
 CYCLONE_LOCAL = ./cyclone -A . -A libs -COPT '-Iinclude' -CLNK '-L.'
 CCOMP = $(CC) $(CFLAGS)
 INDENT_CMD = indent -linux -l80 -i2 -nut


### PR DESCRIPTION
Otherwise, the Cyclone compiler build from cyclone.scm using the
installed Cyclone version will use the libcyclone.a and libcyclonebn.a
file from /usr/lib instead of the one compiled as a prerequisite by
GNU make in the current directory.