### PR TITLE
Improve garbage collection for terminated threads

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2739,7 +2739,7 @@ void gc_thread_data_free(gc_thread_data * thd)
  *
  * This function assumes appropriate locks are already held.
  */
-void gc_heap_merge(gc_heap * hdest, gc_heap * hsrc)
+int gc_heap_merge(gc_heap * hdest, gc_heap * hsrc)
 {
   int freed = 0;
   gc_heap *last = gc_heap_last(hdest);

--- a/gc.c
+++ b/gc.c
@@ -2783,8 +2783,6 @@ void gc_merge_all_heaps(gc_thread_data * dest, gc_thread_data * src)
       freed = gc_heap_merge(hdest, hsrc);
       ck_pr_add_ptr(&(dest->cached_heap_total_sizes[heap_type]),
                     ck_pr_load_ptr(&(src->cached_heap_total_sizes[heap_type]))-freed);
-      ck_pr_add_ptr(&(dest->cached_heap_total_sizes[heap_type]),
-                    ck_pr_load_ptr(&(src->cached_heap_total_sizes[heap_type])));
       ck_pr_add_ptr(&(dest->cached_heap_free_sizes[heap_type]),
                     ck_pr_load_ptr(&(src->cached_heap_free_sizes[heap_type])));
     }

--- a/gc.c
+++ b/gc.c
@@ -2534,6 +2534,14 @@ void gc_collector()
   ck_pr_cas_int(&gc_stage, STAGE_SWEEPING, STAGE_RESTING);
 }
 
+void gc_force(void)
+{
+ /* try to force the collector to run */
+ ck_pr_cas_int(&gc_stage, STAGE_RESTING, STAGE_FORCING);
+ /* if the collector thread was idle, then begin collecting */
+ ck_pr_cas_int(&gc_stage, STAGE_FORCING, STAGE_CLEAR_OR_MARKING);
+}
+
 void *collector_main(void *arg)
 {
   int stage;

--- a/gc.c
+++ b/gc.c
@@ -2769,7 +2769,7 @@ void gc_heap_merge(gc_heap * hdest, gc_heap * hsrc)
 void gc_merge_all_heaps(gc_thread_data * dest, gc_thread_data * src)
 {
   gc_heap *hdest, *hsrc, *cur, *prev;
-  int heap_type;
+  int heap_type, freed;
 
   for (heap_type = 0; heap_type < NUM_HEAP_TYPES; heap_type++) {
     hdest = dest->heap->heap[heap_type];

--- a/gc.c
+++ b/gc.c
@@ -2534,14 +2534,6 @@ void gc_collector()
   ck_pr_cas_int(&gc_stage, STAGE_SWEEPING, STAGE_RESTING);
 }
 
-void gc_force(void)
-{
- /* try to force the collector to run */
- ck_pr_cas_int(&gc_stage, STAGE_RESTING, STAGE_FORCING);
- /* if the collector thread was idle, then begin collecting */
- ck_pr_cas_int(&gc_stage, STAGE_FORCING, STAGE_CLEAR_OR_MARKING);
-}
-
 void *collector_main(void *arg)
 {
   int stage;

--- a/include/cyclone/runtime.h
+++ b/include/cyclone/runtime.h
@@ -53,6 +53,11 @@ void GC(void *, closure, object *, int);
 void gc_init_heap(long heap_size);
 
 /**
+ * \ingroup gc_force
+ */
+void gc_force(void);
+
+/**
  * \defgroup prim Primitives
  * @brief Built-in Scheme functions provided by the runtime library
  *

--- a/include/cyclone/runtime.h
+++ b/include/cyclone/runtime.h
@@ -53,11 +53,6 @@ void GC(void *, closure, object *, int);
 void gc_init_heap(long heap_size);
 
 /**
- * \ingroup gc_force
- */
-void gc_force(void);
-
-/**
  * \defgroup prim Primitives
  * @brief Built-in Scheme functions provided by the runtime library
  *

--- a/include/cyclone/types.h
+++ b/include/cyclone/types.h
@@ -264,7 +264,7 @@ typedef enum { STATUS_ASYNC, STATUS_SYNC1, STATUS_SYNC2
 /** Stages of the Major GC's collector thread */
 typedef enum { STAGE_CLEAR_OR_MARKING, STAGE_TRACING
       //, STAGE_REF_PROCESSING 
-  , STAGE_SWEEPING, STAGE_RESTING, STAGE_FORCING
+  , STAGE_SWEEPING, STAGE_RESTING
 } gc_stage_type;
 
 // Constant colors are defined here.
@@ -377,7 +377,6 @@ struct gc_thread_data_t {
 
 /* GC prototypes */
 void gc_initialize(void);
-void gc_force(void);
 void gc_add_new_unrunning_mutator(gc_thread_data * thd);
 void gc_add_mutator(gc_thread_data * thd);
 void gc_remove_mutator(gc_thread_data * thd);

--- a/include/cyclone/types.h
+++ b/include/cyclone/types.h
@@ -1261,6 +1261,9 @@ typedef pair_type *pair;
   n->pair_car = a; \
   n->pair_cdr = d;
 
+/** Create a new pair in the thread's heap */
+void *gc_alloc_pair(gc_thread_data * data, object head, object tail);
+
 /**
  * Set members of the given pair 
  * @param n - Pointer to a pair object

--- a/include/cyclone/types.h
+++ b/include/cyclone/types.h
@@ -385,7 +385,7 @@ int gc_is_mutator_new(gc_thread_data * thd);
 void gc_sleep_ms(int ms);
 gc_heap *gc_heap_create(int heap_type, size_t size, gc_thread_data * thd);
 gc_heap *gc_heap_free(gc_heap * page, gc_heap * prev_page);
-void gc_heap_merge(gc_heap * hdest, gc_heap * hsrc);
+int gc_heap_merge(gc_heap * hdest, gc_heap * hsrc);
 void gc_merge_all_heaps(gc_thread_data * dest, gc_thread_data * src);
 void gc_print_stats(gc_heap * h);
 gc_heap *gc_grow_heap(gc_heap * h, size_t size, gc_thread_data * thd);

--- a/include/cyclone/types.h
+++ b/include/cyclone/types.h
@@ -264,7 +264,7 @@ typedef enum { STATUS_ASYNC, STATUS_SYNC1, STATUS_SYNC2
 /** Stages of the Major GC's collector thread */
 typedef enum { STAGE_CLEAR_OR_MARKING, STAGE_TRACING
       //, STAGE_REF_PROCESSING 
-  , STAGE_SWEEPING, STAGE_RESTING
+  , STAGE_SWEEPING, STAGE_RESTING, STAGE_FORCING
 } gc_stage_type;
 
 // Constant colors are defined here.
@@ -377,6 +377,7 @@ struct gc_thread_data_t {
 
 /* GC prototypes */
 void gc_initialize(void);
+void gc_force(void);
 void gc_add_new_unrunning_mutator(gc_thread_data * thd);
 void gc_add_mutator(gc_thread_data * thd);
 void gc_remove_mutator(gc_thread_data * thd);

--- a/runtime.c
+++ b/runtime.c
@@ -7181,6 +7181,7 @@ void Cyc_exit_thread(void *data, object _, int argc, object * args)
   gc_remove_mutator(thd);
   ck_pr_cas_int((int *)&(thd->thread_state), CYC_THREAD_STATE_RUNNABLE,
                 CYC_THREAD_STATE_TERMINATED);
+  gc_force();
   pthread_exit(NULL);
 }
 

--- a/runtime.c
+++ b/runtime.c
@@ -5360,7 +5360,7 @@ void _Cyc_91end_91thread_67(void *data, object clo, int argc, object * args)
   vector_type *v = d->scm_thread_obj;
   v->elements[7] = args[0];     // Store thread result
 
-  Cyc_end_thread((gc_thread_data *) data);
+  Cyc_end_thread(d);
   object cont = args[0];
   return_closcall1(data, cont, boolean_f);
 }

--- a/runtime.c
+++ b/runtime.c
@@ -7181,7 +7181,7 @@ void Cyc_exit_thread(void *data, object _, int argc, object * args)
   gc_remove_mutator(thd);
   ck_pr_cas_int((int *)&(thd->thread_state), CYC_THREAD_STATE_RUNNABLE,
                 CYC_THREAD_STATE_TERMINATED);
-  gc_force();
+  gc_start_major_collection(thd);
   pthread_exit(NULL);
 }
 

--- a/srfi/18.sld
+++ b/srfi/18.sld
@@ -142,21 +142,9 @@
         t))
 
     (define (thread-yield!) (thread-sleep! 1))
-
-    (define-c %thread-terminate!
-      "(void *data, int argc, closure _, object k, object thread_data_opaque)"
-      " gc_thread_data *td = (gc_thread_data *)(opaque_ptr(thread_data_opaque));
-        Cyc_end_thread(td);
-        /* TODO: if terminating the current thread, don't return */
-        return_closcall1(data, k, boolean_t);")
-    (define (thread-terminate! t)
-      (cond
-       ((and (thread? t) (Cyc-opaque? (vector-ref t 2)))
-        (begin
-         (Cyc-minor-gc)
-         (%thread-terminate! (vector-ref t 2))))
-       (else
-        #f))) ;; TODO: raise an error instead?
+    (define-c thread-terminate!
+      "(void *data, object _, int argc, object *args)"
+      " Cyc_end_thread(data); ")
 
     ;; TODO: not good enough, need to return value from thread
     ;; TODO: perhaps not an ideal solution using a loop/polling below, but good

--- a/srfi/18.sld
+++ b/srfi/18.sld
@@ -152,7 +152,9 @@
     (define (thread-terminate! t)
       (cond
        ((and (thread? t) (Cyc-opaque? (vector-ref t 2)))
-        (%thread-terminate! (vector-ref t 2)))
+        (begin
+         (Cyc-minor-gc)
+         (%thread-terminate! (vector-ref t 2))))
        (else
         #f))) ;; TODO: raise an error instead?
 
@@ -176,6 +178,7 @@
       (cond
        ((and (thread? t) (Cyc-opaque? (vector-ref t 2)))
         (%thread-join! (vector-ref t 2))
+        (Cyc-minor-gc)
         (vector-ref t 7))
        (else
         #f))) ;; TODO: raise an error instead?

--- a/srfi/18.sld
+++ b/srfi/18.sld
@@ -74,12 +74,14 @@
         ;; - internal
         ;; - end of thread cont (or #f for default)
         ;; - end-result - Result of thread that terminates successfully
+        ;; - internal thread context at termination, e.g. parameterised objects
         (vector 
           'cyc-thread-obj 
           thunk 
           (%alloc-thread-data)  ;; Internal data for new thread
           name-str 
           #f 
+          #f
           #f
           #f
           #f)))


### PR DESCRIPTION
Work on garbage collection, related to issue #534.

When threads terminate, their heaps are merged with the primordial thread's heap. This triggers a minor GC.

Under certain conditions, a major GC will not be triggered and terminated thread's heap pages will nor be swept or freed which can lead to significant memory being used by a program.

These commits attempt to ensure that the heaps are swept and pages are freed when possible.

Some issues that still need to be resolved:

1. The primordial thread does too much work, should the thread which call `pthread-join!` do the work instead?
2. Threads which terminate by `thread-terminate!` are not handled correctly.
3. In the [comment on issue #534](https://github.com/justinethier/cyclone/issues/534#issuecomment-2571743790) the "context" logic needs to be fixed (I thought the "context" would be GC'd with the thread object, but I probably missed something).

I am happy to continue working on this (but unfortunately I am very slow!)