### PR TITLE
pthread-terminate! takes a thread object as argument

### DIFF
--- a/runtime.c
+++ b/runtime.c
@@ -7189,6 +7189,8 @@ void Cyc_exit_thread(void *data, object _, int argc, object * args)
   gc_remove_mutator(thd);
   ck_pr_cas_int((int *)&(thd->thread_state), CYC_THREAD_STATE_RUNNABLE,
                 CYC_THREAD_STATE_TERMINATED);
+  // we are exiting, the destructor does not need to be called
+  pthread_setspecific(cyclone_thread_key, (void (*)(void *))NULL);
   pthread_exit(NULL);
 }
 

--- a/runtime.c
+++ b/runtime.c
@@ -7129,7 +7129,7 @@ void *Cyc_init_thread(object thread_and_thunk, int argc, object * args)
   ck_pr_cas_int((int *)&(thd->thread_state), CYC_THREAD_STATE_NEW,
                 CYC_THREAD_STATE_RUNNABLE);
   if (ck_pr_cas_int(&cyclone_thread_key_create, 1, 0)) {
-    int r = pthread_key_create(&cyclone_thread_key, Cyc_end_thread);
+    int r = pthread_key_create(&cyclone_thread_key, (void (*)(void *))Cyc_end_thread);
     assert(r == 0);
   }
   pthread_setspecific(cyclone_thread_key, thd);

--- a/srfi/18.sld
+++ b/srfi/18.sld
@@ -98,7 +98,7 @@
       (%get-thread-data))
 
     (define *primordial-thread*
-      (vector 'cyc-thread-obj #f #f "main thread" #f #f))
+      (vector 'cyc-thread-obj #f #f "main thread" #f #f #f #f))
 
     (define-c %current-thread
       "(void *data, int argc, closure _, object k)"

--- a/srfi/18.sld
+++ b/srfi/18.sld
@@ -132,9 +132,33 @@
         t))
 
     (define (thread-yield!) (thread-sleep! 1))
-    (define-c thread-terminate!
-      "(void *data, object _, int argc, object *args)"
-      " Cyc_end_thread(data); ")
+
+    (define-c %thread-terminate!
+      "(void *data, int argc, closure _, object k, object thread_data_opaque)"
+      " gc_thread_data *td;
+        if (thread_data_opaque == boolean_f) {
+          /* primordial thread */
+          __halt(boolean_f);
+        } else {
+          td = (gc_thread_data *)(opaque_ptr(thread_data_opaque));
+          if (td == data) {
+            Cyc_end_thread(td);
+          } else {
+            pthread_cancel(td->thread_id);
+          }
+        }
+        return_closcall1(data, k, boolean_t);")
+    (define (thread-terminate! t)
+      (cond
+       ((and (thread? t)
+             (or (Cyc-opaque? (vector-ref t 2)) (equal? *primordial-thread* t)))
+        (begin
+         (Cyc-minor-gc)
+         (vector-set! t 5 (%get-thread-data)) ;; remember calling thread
+         (%thread-terminate! (vector-ref t 2))
+         #t))
+       (else
+        #f))) ;; TODO: raise an error instead?
 
     ;; TODO: not good enough, need to return value from thread
     ;; TODO: perhaps not an ideal solution using a loop/polling below, but good


### PR DESCRIPTION
According to SRFI-18, `pthread-terminate!` takes a thread-object as argument, whereas cyclone `pthread-terminate!` does not take any arguments.

The current implementation terminates the calling thread. This pull request uses `pthread_cancel` to request that the target thread terminates and that `Cyc_end_thread` is called from the target thread.

The case for the `*primordial-thread*` and calling thread being the same as the target thread are handled more or less according to the current implementation.