### PR TITLE
Issue 560 compute stack limit (string-append and bytevector-append)

### DIFF
--- a/include/cyclone/types.h
+++ b/include/cyclone/types.h
@@ -1007,10 +1007,11 @@ typedef struct {
 #define alloc_string(_data, _s, _len, _num_cp) \
  { \
   int stack_left = Cyc_stack_remaining(data); \
-  if (_len >= stack_left) { \
+  int alloc_required = sizeof(string_type) + _len + 1; \
+  if (alloc_required >= stack_left) { \
     int heap_grown; \
     _s = gc_alloc(((gc_thread_data *)data)->heap,  \
-                 sizeof(string_type) + _len + 1, \
+                 alloc_required, \
                  boolean_f, /* OK to populate manually over here */ \
                  (gc_thread_data *)data,  \
                  &heap_grown); \
@@ -1039,10 +1040,11 @@ typedef struct {
 #define alloc_bytevector(_data, _bv, _len) \
  { \
   int stack_left = Cyc_stack_remaining(data); \
-  if (_len >= stack_left) { \
+  int alloc_required = sizeof(bytevector_type) + _len; \
+  if (alloc_required >= stack_left) { \
     int heap_grown; \
     _bv = gc_alloc(((gc_thread_data *)data)->heap, \
-                  sizeof(bytevector_type) + _len, \
+                  alloc_required, \
                   boolean_f, /* OK to populate manually over here */ \
                   (gc_thread_data *)data, \
                   &heap_grown); \

--- a/runtime.c
+++ b/runtime.c
@@ -3185,7 +3185,7 @@ object Cyc_make_vector(void *data, object cont, int argc, object len, ...)
   object v = NULL;
   object fill = boolean_f;
   int i, ulen;
-  size_t element_vec_size;
+  size_t element_vec_size, alloc_required;
   va_list ap;
   make_pair(tmp_pair, NULL, NULL);
   make_c_opaque(opq, NULL);
@@ -3197,14 +3197,15 @@ object Cyc_make_vector(void *data, object cont, int argc, object len, ...)
   Cyc_check_num(data, len);
   ulen = unbox_number(len);
   element_vec_size = sizeof(object) * ulen;
+  alloc_required = sizeof(vector_type) + element_vec_size;
 
-  if (element_vec_size >= Cyc_stack_remaining(data)) {
+  if (alloc_required >= Cyc_stack_remaining(data)) {
     // If vector is too large to allocate on the stack, allocate on heap
     //
     // TODO: mark this thread as potentially blocking before doing
     //       the allocation????
     int heap_grown;
-    v = gc_alloc(((gc_thread_data *) data)->heap, sizeof(vector_type) + element_vec_size, boolean_f,    // OK to populate manually over here
+    v = gc_alloc(((gc_thread_data *) data)->heap, alloc_required, boolean_f,    // OK to populate manually over here
                  (gc_thread_data *) data, &heap_grown);
     ((vector) v)->hdr.mark = ((gc_thread_data *) data)->gc_alloc_color;
     ((vector) v)->hdr.grayed = 0;
@@ -3648,16 +3649,17 @@ object Cyc_list2vector(void *data, object cont, object l)
   object len_obj;
   object lst = l;
   int len, i = 0;
-  size_t element_vec_size;
+  size_t element_vec_size, alloc_required;
 
   make_c_opaque(opq, NULL);
   Cyc_check_pair_or_null(data, l);
   len_obj = Cyc_length(data, l);
   len = obj_obj2int(len_obj);
   element_vec_size = sizeof(object) * len;
-  if (element_vec_size >= Cyc_stack_remaining(data)) {
+  alloc_required = sizeof(vector_type) + element_vec_size;
+  if (alloc_required >= Cyc_stack_remaining(data)) {
     int heap_grown;
-    v = gc_alloc(((gc_thread_data *) data)->heap, sizeof(vector_type) + element_vec_size, boolean_f,    // OK to populate manually over here
+    v = gc_alloc(((gc_thread_data *) data)->heap, alloc_required, boolean_f,    // OK to populate manually over here
                  (gc_thread_data *) data, &heap_grown);
     ((vector) v)->hdr.mark = ((gc_thread_data *) data)->gc_alloc_color;
     ((vector) v)->hdr.grayed = 0;


### PR DESCRIPTION
These commits attempt to address 2 issues:

1.  When checking the available stack space for allocation, use the total size of the allocation instead of string or bytevector (or vector) lengths.
2. Rework `string-append` and `bytevector-append` to use `alloc_string` and `alloc_bytevector` so that the results are now correctly allocated on the stack or heap.

Tested in icyc with:
```
;; loops past the problem points in issue 560
(define s "1234567890")
(let loop ((a s))
   (display (string-length a))
   (newline)
   (loop (string-append a s)))

;; loops past the problem points in issue 560
(define s #u8(1 2 3 4 5 6 7 8 9 0))
(let loop ((a s))
  (display (bytevector-length a))
  (newline)
  (loop (bytevector-append a s)))

;; fails at length 147830
(define s #(1 2 3 4 5 6 7 8 9 0))
  (let loop ((a s))
    (display (vector-length a))
    (newline)
    (loop (vector-append a s)))
```
